### PR TITLE
Creating new job to trigger wordpress

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -88,6 +89,11 @@ jobs:
           docker push kooldev/php:${{ matrix.version }}-nginx${{ matrix.type }}
           docker push kooldev/php:${{ matrix.version }}-nginx-wkhtmltopdf${{ matrix.type }}
 
+  trigger-wordpress:
+    name: Trigger docker-wordpress
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Trigger build on kool-dev/docker-wordpress
         uses: benc-uk/workflow-dispatch@v1.1
         if: github.ref == 'refs/heads/master' && github.repository == 'kool-dev/docker-php'


### PR DESCRIPTION
I move the wordpress trigger to a new job to avoid multiples calls to `kool-dev/docker-wordpress` repository.

## Preview

![image](https://user-images.githubusercontent.com/2936121/95540762-02cc8880-09c8-11eb-8d34-4b68ab0be388.png)
