### PR TITLE
Introduction of MySQLi PHP Extension

### DIFF
--- a/7.1-prod/Dockerfile
+++ b/7.1-prod/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && docker-php-ext-enable imagick \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && pecl install xdebug-2.9.8 \

--- a/7.2-prod/Dockerfile
+++ b/7.2-prod/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && docker-php-ext-enable imagick \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && pecl install xdebug \

--- a/7.3-prod/Dockerfile
+++ b/7.3-prod/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && docker-php-ext-enable imagick \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -57,6 +57,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && pecl install xdebug \

--- a/7.4-prod/Dockerfile
+++ b/7.4-prod/Dockerfile
@@ -54,6 +54,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && docker-php-ext-enable imagick \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -54,6 +54,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     && pecl install imagick \
     && pecl install redis \
     && pecl install xdebug \

--- a/8.0-prod/Dockerfile
+++ b/8.0-prod/Dockerfile
@@ -54,6 +54,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     # Temporarily building for PHP 8.0: https://github.com/Imagick/imagick/issues/358
     && git clone https://github.com/Imagick/imagick \
     && cd imagick \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -54,6 +54,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
     # Temporarily building for PHP 8.0: https://github.com/Imagick/imagick/issues/358
     && git clone https://github.com/Imagick/imagick \
     && cd imagick \

--- a/template/Dockerfile.blade.php
+++ b/template/Dockerfile.blade.php
@@ -66,6 +66,7 @@ RUN adduser -D -u 1337 kool \
         xml \
         zip \
         sockets \
+        mysqli \
 @if (version_compare($version, '8.0', '>='))
     # Temporarily building for PHP 8.0: https://github.com/Imagick/imagick/issues/358
     && git clone https://github.com/Imagick/imagick \


### PR DESCRIPTION
In this PR MySQLi support was introduced so that it is available for use in certain cases, for example: as the main database connection driver used by the CodeIgniter 4 preset on kool.dev