### PR TITLE
Fix PHP 8.5 production opcache extension

### DIFF
--- a/8.5-debian-prod/Dockerfile
+++ b/8.5-debian-prod/Dockerfile
@@ -52,7 +52,6 @@ RUN useradd -m -u 1337 kool \
         intl \
         ldap \
         mbstring \
-        opcache \
         pcntl \
         pdo \
         pdo_mysql \

--- a/8.5-prod/Dockerfile
+++ b/8.5-prod/Dockerfile
@@ -47,7 +47,6 @@ RUN adduser -D -u 1337 kool \
         intl \
         ldap \
         mbstring \
-        opcache \
         pcntl \
         pdo \
         pdo_mysql \

--- a/template/Dockerfile-debian.blade.php
+++ b/template/Dockerfile-debian.blade.php
@@ -55,7 +55,7 @@ RUN useradd -m -u 1337 kool \
         intl \
         ldap \
         mbstring \
-@if ($prod)
+@if ($prod && version_compare($version, '8.5', '<'))
         opcache \
 @endif
         pcntl \

--- a/template/Dockerfile.blade.php
+++ b/template/Dockerfile.blade.php
@@ -57,7 +57,7 @@ RUN adduser -D -u 1337 kool \
         intl \
         ldap \
         mbstring \
-@if ($prod)
+@if ($prod && version_compare($version, '8.5', '<'))
         opcache \
 @endif
         pcntl \


### PR DESCRIPTION
## Ticket
SKIPPED

## Description
Ensure PHP 8.5 production images avoid installing an unsupported opcache extension while preserving opcache for earlier production versions.

## Checklist
### PHP 8.5 Images
- [x] Confirm that PHP 8.5 Alpine production images omit opcache.
- [x] Confirm that PHP 8.5 Debian production images omit opcache.

### Template Output
- [x] Verify that production templates keep opcache for PHP versions below 8.5.
- [x] Check that PHP 8.5 template output matches the generated Dockerfiles.

### Validation
- [x] Verify that the changed Dockerfiles and templates were reviewed against the branch diff.